### PR TITLE
🔒 [security fix] Implement URI validation in ProcessService

### DIFF
--- a/EasyBluetoothAudio.Tests/ProcessServiceTests.cs
+++ b/EasyBluetoothAudio.Tests/ProcessServiceTests.cs
@@ -1,0 +1,42 @@
+using EasyBluetoothAudio.Services;
+using Xunit;
+
+namespace EasyBluetoothAudio.Tests;
+
+public class ProcessServiceTests
+{
+    private readonly ProcessService _service = new();
+
+    [Theory]
+    [InlineData("https://google.com")]
+    [InlineData("http://example.com")]
+    [InlineData("mailto:test@example.com")]
+    [InlineData("ms-settings:bluetooth")]
+    [InlineData("MS-SETTINGS:BLUETOOTH")]
+    public void IsValidUri_ReturnsTrue_ForWhitelistedSchemes(string uri)
+    {
+        Assert.True(_service.IsValidUri(uri));
+    }
+
+    [Theory]
+    [InlineData("file:///C:/Windows/System32/cmd.exe")]
+    [InlineData("C:\\Windows\\explorer.exe")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("ftp://example.com")]
+    [InlineData("cmd.exe")]
+    [InlineData("/etc/passwd")]
+    public void IsValidUri_ReturnsFalse_ForForbiddenSchemesOrPaths(string uri)
+    {
+        Assert.False(_service.IsValidUri(uri));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("not-a-uri")]
+    public void IsValidUri_ReturnsFalse_ForInvalidInput(string? uri)
+    {
+        Assert.False(_service.IsValidUri(uri!));
+    }
+}

--- a/EasyBluetoothAudio/Services/ProcessService.cs
+++ b/EasyBluetoothAudio/Services/ProcessService.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Diagnostics;
+using System.Linq;
 
 namespace EasyBluetoothAudio.Services;
 
@@ -7,9 +9,29 @@ namespace EasyBluetoothAudio.Services;
 /// </summary>
 public class ProcessService : IProcessService
 {
+    private static readonly string[] AllowedSchemes = { "http", "https", "mailto", "ms-settings" };
+
     /// <inheritdoc />
     public void OpenUri(string uri)
     {
-        Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true });
+        if (IsValidUri(uri))
+        {
+            Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true });
+        }
+    }
+
+    internal bool IsValidUri(string uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsedUri))
+        {
+            return false;
+        }
+
+        return AllowedSchemes.Contains(parsedUri.Scheme.ToLowerInvariant());
     }
 }


### PR DESCRIPTION
### 🎯 What:
The `OpenUri` method in `ProcessService` was blindly executing input strings using `Process.Start` with `UseShellExecute = true`.

### ⚠️ Risk:
This vulnerability allowed for generic command execution. If an attacker could control the input string, they could execute local binaries or scripts (e.g., `C:\Windows\System32\cmd.exe` or `file:///...`) by passing a path or a `file://` URI.

### 🛡️ Solution:
Implemented a whitelist-based URI validation. The method now only allows absolute URIs with the following schemes: `http`, `https`, `mailto`, and `ms-settings`. 

- Added `IsValidUri` internal method for validation.
- Whitelisted schemes: `http`, `https`, `mailto`, `ms-settings`.
- Rejects `file`, `javascript`, and other potentially dangerous schemes.
- Added `EasyBluetoothAudio.Tests/ProcessServiceTests.cs` with test cases for whitelisted, forbidden, and malformed inputs.
- Verified the logic via a standalone tool as the full test suite requires a Windows environment to run.

---
*PR created automatically by Jules for task [6841599541639380887](https://jules.google.com/task/6841599541639380887) started by @GorangN*