### PR TITLE
🧪 BluetoothDevice: Test Property Change Optimization

### DIFF
--- a/EasyBluetoothAudio.Tests/BluetoothDeviceTests.cs
+++ b/EasyBluetoothAudio.Tests/BluetoothDeviceTests.cs
@@ -55,16 +55,30 @@ public class BluetoothDeviceTests
         Assert.Equal("IsPhoneOrComputer", raisedProperty);
     }
 
-    [Fact]
-    public void Setting_SameValue_DoesNotRaisePropertyChanged()
+    [Theory]
+    [InlineData(nameof(BluetoothDevice.Name), "iPhone")]
+    [InlineData(nameof(BluetoothDevice.Id), "device-123")]
+    [InlineData(nameof(BluetoothDevice.IsConnected), true)]
+    [InlineData(nameof(BluetoothDevice.IsPhoneOrComputer), true)]
+    public void Setting_SameValue_DoesNotRaisePropertyChanged(string propertyName, object value)
     {
-        var device = new BluetoothDevice { Name = "iPhone" };
+        var device = new BluetoothDevice();
+        var property = typeof(BluetoothDevice).GetProperty(propertyName)!;
+
+        // Set initial value
+        property.SetValue(device, value);
+
         bool raised = false;
-        device.PropertyChanged += (s, e) => raised = true;
+        device.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == propertyName)
+                raised = true;
+        };
 
-        device.Name = "iPhone";
+        // Set same value again
+        property.SetValue(device, value);
 
-        Assert.False(raised);
+        Assert.False(raised, $"Property {propertyName} should not raise PropertyChanged when set to the same value.");
     }
 
     [Fact]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a negative test case for the `BluetoothDevice` model to ensure that its properties correctly implement change notification optimization (i.e., they do not raise the `PropertyChanged` event if the value has not changed).

📊 **Coverage:** What scenarios are now tested
The `Setting_SameValue_DoesNotRaisePropertyChanged` test has been expanded to cover:
- `Name`
- `Id`
- `IsConnected`
- `IsPhoneOrComputer`

✨ **Result:** The improvement in test coverage
Ensures that all key properties of the `BluetoothDevice` model follow the expected optimization pattern, preventing unnecessary UI updates and potential performance issues.

---
*PR created automatically by Jules for task [15182063215834104789](https://jules.google.com/task/15182063215834104789) started by @GorangN*