### PR TITLE
🧹 Remove unused System.Windows.Input namespace in UpdateViewModel

### DIFF
--- a/EasyBluetoothAudio/ViewModels/UpdateViewModel.cs
+++ b/EasyBluetoothAudio/ViewModels/UpdateViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using EasyBluetoothAudio.Models;
 using EasyBluetoothAudio.Services.Interfaces;


### PR DESCRIPTION
🎯 **What:** Removed unused `System.Windows.Input` import from `UpdateViewModel.cs`.
💡 **Why:** Commands in this ViewModel rely on `CommunityToolkit.Mvvm` attributes, rendering the explicit `System.Windows.Input` namespace reference unnecessary. This cleans up unused code and improves readability.
✅ **Verification:** Verified by compiling the project with `dotnet build -p:EnableWindowsTargeting=true`. The compilation succeeded with zero warnings, confirming no functionality is broken.
✨ **Result:** Improved code health and maintainability by removing redundant code.

---
*PR created automatically by Jules for task [8558130778200610592](https://jules.google.com/task/8558130778200610592) started by @GorangN*