### PR TITLE
🧪 Add unit tests for AppSettings model

### DIFF
--- a/EasyBluetoothAudio.Tests/AppSettingsTests.cs
+++ b/EasyBluetoothAudio.Tests/AppSettingsTests.cs
@@ -1,0 +1,46 @@
+using EasyBluetoothAudio.Models;
+
+namespace EasyBluetoothAudio.Tests;
+
+public class AppSettingsTests
+{
+    [Fact]
+    public void DefaultValues_AreSetCorrectly()
+    {
+        var settings = new AppSettings();
+
+        Assert.False(settings.AutoStartOnStartup);
+        Assert.False(settings.AutoConnect);
+        Assert.Null(settings.LastDeviceId);
+        Assert.Equal(AppThemeMode.Dark, settings.ThemeMode);
+        Assert.Null(settings.PreferredDeviceId);
+        Assert.Equal(ReconnectTimeout.ThirtySeconds, settings.ReconnectTimeout);
+        Assert.True(settings.ShowNotifications);
+        Assert.False(settings.PlayConnectionSound);
+    }
+
+    [Fact]
+    public void Property_GettersAndSetters_WorkCorrectly()
+    {
+        var settings = new AppSettings
+        {
+            AutoStartOnStartup = true,
+            AutoConnect = true,
+            LastDeviceId = "device123",
+            ThemeMode = AppThemeMode.Light,
+            PreferredDeviceId = "device456",
+            ReconnectTimeout = ReconnectTimeout.SixtySeconds,
+            ShowNotifications = false,
+            PlayConnectionSound = true
+        };
+
+        Assert.True(settings.AutoStartOnStartup);
+        Assert.True(settings.AutoConnect);
+        Assert.Equal("device123", settings.LastDeviceId);
+        Assert.Equal(AppThemeMode.Light, settings.ThemeMode);
+        Assert.Equal("device456", settings.PreferredDeviceId);
+        Assert.Equal(ReconnectTimeout.SixtySeconds, settings.ReconnectTimeout);
+        Assert.False(settings.ShowNotifications);
+        Assert.True(settings.PlayConnectionSound);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The AppSettings model lacked unit tests to verify its default values and basic property setter/getter functionality.
📊 **Coverage:** Added test coverage for `AppSettings` default initialization and property assignments, verifying that defaults like `ThemeMode` and `ReconnectTimeout` behave correctly. 
✨ **Result:** Improved overall project test coverage and ensured standard POCO behavior won't unexpectedly fail or diverge from expected default values.

---
*PR created automatically by Jules for task [2887508481272847841](https://jules.google.com/task/2887508481272847841) started by @GorangN*