### PR TITLE
🧪 [Testing Improvement] Add test for UpdateViewModel InstallUpdateAsync error handling

### DIFF
--- a/EasyBluetoothAudio.Tests/UpdateViewModelTests.cs
+++ b/EasyBluetoothAudio.Tests/UpdateViewModelTests.cs
@@ -31,4 +31,35 @@ public class UpdateViewModelTests
         // Assert
         Assert.Equal("RATE LIMIT EXCEEDED", updatedStatus);
     }
+
+    [Fact]
+    public async Task InstallUpdateAsync_SetsStatusText_WhenExceptionOccurs()
+    {
+        // Arrange
+        var mockUpdateService = new Mock<IUpdateService>();
+        var fakeUpdate = new UpdateInfo("v1.2.3", "1.2.3", "http://example.com/installer.exe", "Release Notes");
+
+        mockUpdateService
+            .Setup(s => s.CheckForUpdateAsync(It.IsAny<System.Threading.CancellationToken>()))
+            .ReturnsAsync(fakeUpdate);
+
+        var expectedExceptionMessage = "Download failed";
+        mockUpdateService
+            .Setup(s => s.DownloadAndInstallAsync(fakeUpdate, It.IsAny<System.Threading.CancellationToken>()))
+            .ThrowsAsync(new Exception(expectedExceptionMessage));
+
+        var vm = new UpdateViewModel(mockUpdateService.Object);
+
+        // Populate _latestUpdate
+        await vm.CheckForUpdateAsync();
+
+        string? lastStatus = null;
+        vm.StatusTextChanged += status => lastStatus = status;
+
+        // Act
+        await vm.InstallUpdateAsync();
+
+        // Assert
+        Assert.Equal($"UPDATE FAILED: {expectedExceptionMessage}", lastStatus);
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `InstallUpdateAsync` method in `UpdateViewModel` had error handling logic using a try/catch block to update the `StatusTextChanged` event when `DownloadAndInstallAsync` throws an exception, but it lacked a test to verify this behavior.

📊 **Coverage:** What scenarios are now tested
A new test `InstallUpdateAsync_SetsStatusText_WhenExceptionOccurs` has been added. It:
1. Mocks `IUpdateService` to successfully return an update in `CheckForUpdateAsync` so `_latestUpdate` is set.
2. Mocks `DownloadAndInstallAsync` to throw a specific exception.
3. Invokes `InstallUpdateAsync`.
4. Asserts that `StatusTextChanged` emits exactly the expected "UPDATE FAILED: [Message]" text.

✨ **Result:** The improvement in test coverage
The error path inside `InstallUpdateAsync` is now fully verified by tests, ensuring that regressions won't break the user-facing status feedback during failed application updates.

---
*PR created automatically by Jules for task [2870320294478600172](https://jules.google.com/task/2870320294478600172) started by @GorangN*