### PR TITLE
🧪 [Testing Improvement] Add test for SettingsService handling corrupted JSON

### DIFF
--- a/EasyBluetoothAudio.Tests/SettingsServiceTests.cs
+++ b/EasyBluetoothAudio.Tests/SettingsServiceTests.cs
@@ -56,6 +56,27 @@ public class SettingsServiceTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that Load returns default values when the settings file contains corrupted JSON.
+    /// </summary>
+    [Fact]
+    public void Load_ReturnsDefaults_WhenJsonIsCorrupted()
+    {
+        var filePath = Path.Combine(_tempPath, "settings.json");
+        File.WriteAllText(filePath, "{ invalid json data ");
+
+        var result = _sut.Load();
+
+        Assert.False(result.AutoStartOnStartup);
+        Assert.False(result.AutoConnect);
+        Assert.Null(result.LastDeviceId);
+        Assert.Equal(AppThemeMode.Dark, result.ThemeMode);
+        Assert.Null(result.PreferredDeviceId);
+        Assert.Equal(ReconnectTimeout.ThirtySeconds, result.ReconnectTimeout);
+        Assert.True(result.ShowNotifications);
+        Assert.False(result.PlayConnectionSound);
+    }
+
+    /// <summary>
     /// Verifies that all settings properties round-trip through Save/Load correctly.
     /// </summary>
     [Fact]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the catch block in `SettingsService.Load()` when `JsonSerializer.Deserialize` fails due to corrupted JSON file content.

📊 **Coverage:** The scenario where a user has an existing `settings.json` file but it contains invalid JSON is now tested. The new test verifies that `Load()` safely handles this exception and returns a default `AppSettings` object rather than crashing the application.

✨ **Result:** Increased test coverage by ensuring the exception handling branch of the `Load()` method in `SettingsService` is verified and acts as expected.

---
*PR created automatically by Jules for task [18308516006790447282](https://jules.google.com/task/18308516006790447282) started by @GorangN*