### PR TITLE
🔒 Fix arbitrary command execution vulnerability via Process.Start in ProcessService

### DIFF
--- a/EasyBluetoothAudio/Services/ProcessService.cs
+++ b/EasyBluetoothAudio/Services/ProcessService.cs
@@ -15,20 +15,27 @@ public class ProcessService : IProcessService
     /// <inheritdoc />
     public void OpenUri(string uri)
     {
-        if (IsValidUri(uri))
+        if (IsValidUri(uri, out var parsedUri) && parsedUri != null)
         {
-            Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo(parsedUri.AbsoluteUri) { UseShellExecute = true });
         }
     }
 
     internal bool IsValidUri(string uri)
     {
+        return IsValidUri(uri, out _);
+    }
+
+    private bool IsValidUri(string uri, out Uri? parsedUri)
+    {
+        parsedUri = null;
+
         if (string.IsNullOrWhiteSpace(uri))
         {
             return false;
         }
 
-        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsedUri))
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out parsedUri))
         {
             return false;
         }


### PR DESCRIPTION
🎯 **What:** Fixed a potential arbitrary command execution vulnerability in `ProcessService.cs` when handling shell execution.
⚠️ **Risk:** When `Process.Start` is called with `UseShellExecute = true`, raw input strings are evaluated by the shell. Without proper encoding, a malicious URI (e.g. `ms-settings:bluetooth" & calc.exe`) could inject shell commands that the system would blindly execute.
🛡️ **Solution:** Altered `ProcessService` to parse the URI and utilize `parsedUri.AbsoluteUri`. This forces proper URL encoding (e.g., spaces and quotes become `%20` and `%22`), effectively escaping characters that could break out of the URI context and execute arbitrary binaries. Refactored `IsValidUri` cleanly to avoid duplicated parsing and maintained backwards-compatibility with existing tests.

---
*PR created automatically by Jules for task [11401286395150846830](https://jules.google.com/task/11401286395150846830) started by @GorangN*