### PR TITLE
🧪 [Testing] Add StartupService Registry Tests

### DIFF
--- a/EasyBluetoothAudio.Tests/StartupServiceTests.cs
+++ b/EasyBluetoothAudio.Tests/StartupServiceTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using EasyBluetoothAudio.Services;
+using Microsoft.Win32;
+using Xunit;
+
+namespace EasyBluetoothAudio.Tests;
+
+public class StartupServiceTests : IDisposable
+{
+    private const string TestRegistryKeyPath = @"Software\EasyBluetoothAudio\TestStartup";
+    private const string TestAppName = "TestEasyBluetoothAudio";
+
+    private readonly StartupService? _sut;
+
+    public StartupServiceTests()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Ensure a clean state by creating the test registry key.
+            // This guarantees that OpenSubKey won't fail due to missing path.
+            using var key = Registry.CurrentUser.CreateSubKey(TestRegistryKeyPath);
+
+            _sut = new StartupService(TestRegistryKeyPath, TestAppName);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Clean up test registry key after tests
+            Registry.CurrentUser.DeleteSubKeyTree(TestRegistryKeyPath, throwOnMissingSubKey: false);
+        }
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalse_WhenNotSet()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+
+        Assert.NotNull(_sut);
+
+        // Ensure no leftover value exists before test.
+        using (var key = Registry.CurrentUser.OpenSubKey(TestRegistryKeyPath, writable: true))
+        {
+            key?.DeleteValue(TestAppName, throwOnMissingValue: false);
+        }
+
+        var isEnabled = _sut.IsEnabled;
+
+        Assert.False(isEnabled);
+    }
+
+    [Fact]
+    public void Enable_SetsRegistryKey_And_IsEnabled_ReturnsTrue()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+
+        Assert.NotNull(_sut);
+
+        _sut.Enable();
+
+        var isEnabled = _sut.IsEnabled;
+        Assert.True(isEnabled);
+
+        // Verify the expected value in registry
+        using var key = Registry.CurrentUser.OpenSubKey(TestRegistryKeyPath, writable: false);
+        var value = key?.GetValue(TestAppName) as string;
+
+        var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+        Assert.Equal($"\"{exePath}\" --silent", value);
+    }
+
+    [Fact]
+    public void Disable_RemovesRegistryKey_And_IsEnabled_ReturnsFalse()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+
+        Assert.NotNull(_sut);
+
+        // First, enable it
+        _sut.Enable();
+        Assert.True(_sut.IsEnabled);
+
+        // Then, disable it
+        _sut.Disable();
+
+        var isEnabled = _sut.IsEnabled;
+        Assert.False(isEnabled);
+
+        // Verify value is actually removed from registry
+        using var key = Registry.CurrentUser.OpenSubKey(TestRegistryKeyPath, writable: false);
+        var value = key?.GetValue(TestAppName);
+        Assert.Null(value);
+    }
+}

--- a/EasyBluetoothAudio/Services/StartupService.cs
+++ b/EasyBluetoothAudio/Services/StartupService.cs
@@ -9,16 +9,29 @@ namespace EasyBluetoothAudio.Services;
 /// </summary>
 public class StartupService : IStartupService
 {
-    private const string RegistryKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
-    private const string AppName = "EasyBluetoothAudio";
+    private readonly string _registryKeyPath;
+    private readonly string _appName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StartupService"/> class.
+    /// </summary>
+    public StartupService() : this(@"Software\Microsoft\Windows\CurrentVersion\Run", "EasyBluetoothAudio")
+    {
+    }
+
+    internal StartupService(string registryKeyPath, string appName)
+    {
+        _registryKeyPath = registryKeyPath;
+        _appName = appName;
+    }
 
     /// <inheritdoc />
     public bool IsEnabled
     {
         get
         {
-            using var key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath, writable: false);
-            return key?.GetValue(AppName) != null;
+            using var key = Registry.CurrentUser.OpenSubKey(_registryKeyPath, writable: false);
+            return key?.GetValue(_appName) != null;
         }
     }
 
@@ -31,14 +44,14 @@ public class StartupService : IStartupService
             return;
         }
 
-        using var key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath, writable: true);
-        key?.SetValue(AppName, $"\"{exePath}\" --silent");
+        using var key = Registry.CurrentUser.OpenSubKey(_registryKeyPath, writable: true);
+        key?.SetValue(_appName, $"\"{exePath}\" --silent");
     }
 
     /// <inheritdoc />
     public void Disable()
     {
-        using var key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath, writable: true);
-        key?.DeleteValue(AppName, throwOnMissingValue: false);
+        using var key = Registry.CurrentUser.OpenSubKey(_registryKeyPath, writable: true);
+        key?.DeleteValue(_appName, throwOnMissingValue: false);
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `StartupService` manages the application's auto-start behavior by reading and writing to the Windows Registry (`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`). This logic was entirely untested because the hardcoded registry path made it impossible to test without directly modifying the actual user's system configuration, risking unintended side-effects.

📊 **Coverage:** What scenarios are now tested
- I refactored `StartupService.cs` to accept a custom registry key path and application name via an internal constructor (leaving the default behavior untouched for production). 
- I added `StartupServiceTests.cs` that verifies the behavior of `Enable()`, `Disable()`, and `IsEnabled` methods using a safe dummy registry key (`Software\EasyBluetoothAudio\TestStartup`).
- Tests are guarded with `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` so they safely no-op when the test suite runs on Linux/macOS build servers or in sandboxes without Windows registry support.
- IDisposable pattern is used in the test class to ensure the dummy registry subkey is properly cleaned up after tests finish executing.

✨ **Result:** The improvement in test coverage
The critical auto-start registry interactions are now fully tested. We can confidently refactor or extend the startup behavior knowing our test suite will catch regressions, all without polluting the user's real `Run` registry key.

---
*PR created automatically by Jules for task [2166664991357961299](https://jules.google.com/task/2166664991357961299) started by @GorangN*