### PR TITLE
🧪 Add unit tests for InverseBooleanToVisibilityConverter

### DIFF
--- a/EasyBluetoothAudio.Tests/Converters/InverseBooleanToVisibilityConverterTests.cs
+++ b/EasyBluetoothAudio.Tests/Converters/InverseBooleanToVisibilityConverterTests.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using System.Windows;
+using EasyBluetoothAudio.Converters;
+
+namespace EasyBluetoothAudio.Tests.Converters;
+
+public class InverseBooleanToVisibilityConverterTests
+{
+    private readonly InverseBooleanToVisibilityConverter _converter;
+
+    public InverseBooleanToVisibilityConverterTests()
+    {
+        _converter = new InverseBooleanToVisibilityConverter();
+    }
+
+    [Fact]
+    public void Convert_WhenValueIsTrue_ReturnsCollapsed()
+    {
+        var result = _converter.Convert(true, typeof(Visibility), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal(Visibility.Collapsed, result);
+    }
+
+    [Fact]
+    public void Convert_WhenValueIsFalse_ReturnsVisible()
+    {
+        var result = _converter.Convert(false, typeof(Visibility), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal(Visibility.Visible, result);
+    }
+
+    [Fact]
+    public void Convert_WhenValueIsNotBoolean_ReturnsVisible()
+    {
+        var result = _converter.Convert("not a boolean", typeof(Visibility), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal(Visibility.Visible, result);
+    }
+
+    [Fact]
+    public void Convert_WhenValueIsNull_ReturnsVisible()
+    {
+        var result = _converter.Convert(null!, typeof(Visibility), null!, CultureInfo.InvariantCulture);
+
+        Assert.Equal(Visibility.Visible, result);
+    }
+
+    [Fact]
+    public void ConvertBack_WhenValueIsCollapsed_ReturnsTrue()
+    {
+        var result = _converter.ConvertBack(Visibility.Collapsed, typeof(bool), null!, CultureInfo.InvariantCulture);
+
+        Assert.True((bool)result);
+    }
+
+    [Fact]
+    public void ConvertBack_WhenValueIsHidden_ReturnsTrue()
+    {
+        var result = _converter.ConvertBack(Visibility.Hidden, typeof(bool), null!, CultureInfo.InvariantCulture);
+
+        Assert.True((bool)result);
+    }
+
+    [Fact]
+    public void ConvertBack_WhenValueIsVisible_ReturnsFalse()
+    {
+        var result = _converter.ConvertBack(Visibility.Visible, typeof(bool), null!, CultureInfo.InvariantCulture);
+
+        Assert.False((bool)result);
+    }
+
+    [Fact]
+    public void ConvertBack_WhenValueIsNotVisibility_ReturnsFalse()
+    {
+        var result = _converter.ConvertBack("not visibility", typeof(bool), null!, CultureInfo.InvariantCulture);
+
+        Assert.False((bool)result);
+    }
+
+    [Fact]
+    public void ConvertBack_WhenValueIsNull_ReturnsFalse()
+    {
+        var result = _converter.ConvertBack(null!, typeof(bool), null!, CultureInfo.InvariantCulture);
+
+        Assert.False((bool)result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added missing unit tests for the `InverseBooleanToVisibilityConverter` in `EasyBluetoothAudio/Converters/InverseBooleanToVisibilityConverter.cs`. This ensures the conversion logic behaves as expected for various inputs.

📊 **Coverage:** What scenarios are now tested
- `Convert`: Covered `true`, `false`, non-boolean inputs, and `null` inputs.
- `ConvertBack`: Covered `Visibility.Collapsed`, `Visibility.Hidden`, `Visibility.Visible`, non-visibility enum inputs, and `null` inputs.

✨ **Result:** The improvement in test coverage
We now have full code coverage for `InverseBooleanToVisibilityConverter`, protecting this simple but critical UI logic from unexpected regressions. The tests are purely stateless and deterministic, adhering strictly to existing project conventions and using `null!` where appropriate to test edge cases while maintaining zero compiler warnings.

---
*PR created automatically by Jules for task [12213507568167941768](https://jules.google.com/task/12213507568167941768) started by @GorangN*