### PR TITLE
🧪 Add missing error path test for UpdateService

### DIFF
--- a/EasyBluetoothAudio.Tests/UpdateServiceTests.cs
+++ b/EasyBluetoothAudio.Tests/UpdateServiceTests.cs
@@ -142,4 +142,14 @@ public class UpdateServiceTests
         // The stored version strips the pre-release suffix
         Assert.Equal("999.0.0", result.Version);
     }
+
+    [Fact]
+    public async Task CheckForUpdateAsync_ReturnsNull_OnMalformedJson()
+    {
+        var svc = new UpdateService(MakeHttpClient("{ invalid json }"));
+
+        var result = await svc.CheckForUpdateAsync();
+
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of coverage for the error path in `UpdateService.CheckForUpdateAsync` where the GitHub API returns an invalid or malformed JSON payload.
📊 **Coverage:** The scenario where `_http.GetFromJsonAsync` (or the underlying `System.Text.Json` deserializer) throws an exception due to bad JSON format is now properly tested to ensure the service gracefully catches it and returns `null` instead of crashing.
✨ **Result:** Improved robustness and test coverage for the `UpdateService`, providing confidence that the application handles unpredictable or malformed GitHub API responses cleanly.

---
*PR created automatically by Jules for task [10483704821796527267](https://jules.google.com/task/10483704821796527267) started by @GorangN*