### PR TITLE
🧪 [testing improvement] Add Error Handling Test for ProcessService.IsValidUri

### DIFF
--- a/EasyBluetoothAudio.Tests/ProcessServiceTests.cs
+++ b/EasyBluetoothAudio.Tests/ProcessServiceTests.cs
@@ -36,6 +36,9 @@ public class ProcessServiceTests
     [InlineData("   ")]
     [InlineData(null)]
     [InlineData("not-a-uri")]
+    [InlineData("http://")]
+    [InlineData("https://")]
+    [InlineData("http://exam ple.com")]
     public void IsValidUri_ReturnsFalse_ForInvalidInput(string? uri)
     {
         Assert.False(_service.IsValidUri(uri!));


### PR DESCRIPTION
### 🧪 [testing improvement] Add Error Handling Test for ProcessService.IsValidUri

🎯 **What:** The testing gap addressed
Identify and test edge cases for URI validation in `ProcessService.IsValidUri` that were previously missing.

📊 **Coverage:** What scenarios are now tested
- Malformed URIs with missing host components (`http://`, `https://`)
- URIs containing illegal characters (`http://exam ple.com`)

✨ **Result:** The improvement in test coverage
Increased reliability of the URI validation logic by ensuring it correctly rejects malformed absolute URIs.

Note: `mailto:` and `ms-settings:` were investigated but found to be valid absolute URIs in .NET, so they were excluded from the 'invalid' test cases.

---
*PR created automatically by Jules for task [7746822140490520058](https://jules.google.com/task/7746822140490520058) started by @GorangN*